### PR TITLE
Feature/cleanup build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,8 @@ publishing {
 }
 
 bintray {
-    user = bintrayUser
-    key = bintrayKey
+    user = null // TODO: Replace
+    key = null // TODO: Replace
     publications = ['mavenJava']
     pkg {
         repo = 'icon-version'

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,6 @@ targetCompatibility = JavaVersion.VERSION_1_6
 repositories {
     jcenter()
     mavenCentral()
-    maven {
-        url 'http://oss.sonatype.org/content/repositories/snapshots/'
-    }
 }
 
 dependencies {
@@ -32,7 +29,9 @@ dependencies {
     compile 'com.android.tools.build:gradle:0.14.+'
     compile 'com.google.guava:guava:16.0.1'
 
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.3-SNAPSHOT'
+    testCompile ('org.spockframework:spock-core:1.0-groovy-2.3') {
+        exclude module: 'groovy-all'
+    }
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/src/test/groovy/pl/itako/iconversion/IconUtilsTest.groovy
+++ b/src/test/groovy/pl/itako/iconversion/IconUtilsTest.groovy
@@ -7,7 +7,7 @@ import static pl.itako.iconversion.IconUtils.findIcons
 
 class IconUtilsTest extends Specification {
 
-    def "addWatermark test"() {
+    def "test addWatermark"() {
         given:
         InputStream is = getClass().getResourceAsStream('/test_icons/drawable-xxhdpi/ic_launcher.png')
 


### PR DESCRIPTION
No longer need the 'snapshot' version.

Also removed the 'bintrayUser/bintrayKey' so that compilation works without any modifications.