### PR TITLE
Version name suffix

### DIFF
--- a/src/main/groovy/pl/itako/iconversion/IconVersionPlugin.groovy
+++ b/src/main/groovy/pl/itako/iconversion/IconVersionPlugin.groovy
@@ -44,7 +44,7 @@ class IconVersionPlugin implements Plugin<Project> {
                             log.info "Adding flavor name and version to: " + icon.absolutePath
 
                             def buildName = variant.flavorName + " " + variant.buildType.name
-                            def version = variant.mergedFlavor.versionName
+                            def version = variant.versionName
 
                             addTextToImage(icon, config, buildName, version)
                         }


### PR DESCRIPTION
Ensure that the version name used on the icon includes the 'versionNameSuffix' defined on the buildType was not being included in the label.

This PR uses the variant versionName to ensure that it's actual output value is used instead.